### PR TITLE
Replace deprecated GObject calls with GLib equivalents

### DIFF
--- a/src/syncstate.py
+++ b/src/syncstate.py
@@ -26,7 +26,7 @@ import socket
 import tempfile
 import time
 
-from gi.repository import GObject, Nautilus
+from gi.repository import GObject, GLib, Nautilus
 
 # Note: setappname.sh will search and replace 'ownCloud' on this file to update this line and other
 # occurrences of the name
@@ -70,13 +70,13 @@ class SocketConnect(GObject.GObject):
 
         # returns true when one should try again!
         if self._connectToSocketServer():
-            GObject.timeout_add(5000, self._connectToSocketServer)
+            GLib.timeout_add(5000, self._connectToSocketServer)
 
     def reconnect(self):
         self._sock.close()
         self.connected = False
-        GObject.source_remove(self._watch_id)
-        GObject.timeout_add(5000, self._connectToSocketServer)
+        GLib.source_remove(self._watch_id)
+        GLib.timeout_add(5000, self._connectToSocketServer)
 
     def sendCommand(self, cmd):
         # print("Server command: " + cmd)
@@ -99,7 +99,7 @@ class SocketConnect(GObject.GObject):
             try:
                 self._sock.connect(sock_file) # fails if sock_file doesn't exist
                 self.connected = True
-                self._watch_id = GObject.io_add_watch(self._sock, GObject.IO_IN, self._handle_notify)
+                self._watch_id = GLib.io_add_watch(self._sock, GLib.PRIORITY_DEFAULT, GLib.IOCondition.IN, self._handle_notify)
 
                 self.sendCommand('VERSION:\n')
                 self.sendCommand('GET_STRINGS:\n')


### PR DESCRIPTION
## Summary
- Replace deprecated `GObject.io_add_watch`, `GObject.IO_IN`, `GObject.timeout_add`, and `GObject.source_remove` with their `GLib` equivalents
- These deprecated calls cause a fatal crash on **Python 3.14 + PyGObject 3.54**, making Nautilus enter a crash loop on initialization
- The crash also breaks file dialogs system-wide via `xdg-desktop-portal-gnome`

Fixes owncloud/client#12464

## Changes
- `GObject.timeout_add` → `GLib.timeout_add`
- `GObject.source_remove` → `GLib.source_remove`
- `GObject.io_add_watch(sock, GObject.IO_IN, cb)` → `GLib.io_add_watch(sock, GLib.PRIORITY_DEFAULT, GLib.IOCondition.IN, cb)`
- Added `GLib` to the imports from `gi.repository`

## Test plan
- [x] Fix verified by the issue reporter on Manjaro Linux with Python 3.14.2, PyGObject 3.54.5, Nautilus 49.3
- [ ] Confirm Nautilus starts without crash loop after applying the patch
- [ ] Confirm file dialogs work correctly via `xdg-desktop-portal-gnome`
- [ ] Confirm ownCloud sync state overlays still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)