### PR TITLE
ci: pin actions/checkout to SHA for org sha-pinning policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Checkout resources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: owncloud/client-desktop-shell-integration-resources
           path: resources


### PR DESCRIPTION
## Summary

- Cherry-pick of 907ce341c85fea6440dd70a081240bc679d3aa3f
- Pins `actions/checkout` to its full SHA to comply with the org's SHA-pinning policy for GitHub Actions

## Test plan

- [ ] Verify CI workflows run successfully after the pin change
- [ ] Confirm the pinned SHA corresponds to the expected `actions/checkout` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)